### PR TITLE
Dockerize the relaton application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+log
+tmp

--- a/.sample.env
+++ b/.sample.env
@@ -1,0 +1,14 @@
+# https://github.com/ddollar/forego
+ASSET_HOST=localhost:3000
+APPLICATION_HOST=localhost:3000
+PORT=3000
+RACK_ENV=development
+RACK_MINI_PROFILER=0
+SECRET_KEY_BASE=development_secret
+EXECJS_RUNTIME=Node
+SMTP_ADDRESS=smtp.example.com
+SMTP_DOMAIN=example.com
+SMTP_PASSWORD=password
+SMTP_USERNAME=username
+WEB_CONCURRENCY=1
+RACK_TIMEOUT_SERVICE_TIMEOUT=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:2.6-slim-stretch
+
+RUN apt-get update -qq && apt-get install -yy curl wget
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get update && apt-get install -qq -y nodejs build-essential \
+    libxml2-dev libxslt1-dev libqtwebkit4 libqt4-dev xvfb wait-for-it \
+    libpq-dev --fix-missing --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# install latest bundler
+RUN gem install bundler
+RUN npm install yarn -g
+
+# Create app directory
+WORKDIR /relaton.org
+
+# Copy gemfile
+COPY Gemfile* ./
+
+# Install dependencies
+RUN bundle install
+
+# Copy the application
+COPY . .
+
+
+CMD ["./entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby "2.6.3"
 
 gem "autoprefixer-rails"
 gem "bootsnap", require: false
+gem "daemons"
 gem "delayed_job_active_record"
 gem "honeybadger"
 gem "oj"
@@ -22,7 +23,6 @@ gem "skylight"
 gem "simple_form"
 gem "sprockets", ">= 3.0.0"
 gem "title"
-gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
 gem "uglifier"
 gem "rack-timeout", group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    daemons (1.3.1)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.3)
@@ -297,6 +298,7 @@ DEPENDENCIES
   bundler-audit (>= 0.5.0)
   capybara-selenium
   chromedriver-helper
+  daemons
   delayed_job_active_record
   dotenv-rails
   factory_bot_rails
@@ -326,7 +328,6 @@ DEPENDENCIES
   suspenders
   timecop
   title
-  tzinfo-data
   uglifier
   web-console
   webmock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: up
+up:
+	docker-compose up
+
+.PHONY: down
+down:
+	docker-compose down
+
+.PHONY: test
+test: rspec
+
+.PHONY: rspec
+rspec:
+	docker-compose run web bin/rspec
+
+.PHONY: console
+console:
+	docker-compose run web bin/rails console
+
+.PHONY: setup
+setup:
+	docker-compose up --build
+	docker-compose run web bin/rails db:setup

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Getting Started
 
+### Native development
+
 After you have cloned this repo, run this setup script to set up your machine
 with the necessary dependencies to run and test this app:
 
@@ -20,6 +22,31 @@ After setting up, you can run the application using [Heroku Local]:
 # or plain old
 bin/rails server
 ```
+
+### Development with docker
+
+If you prefer to run this application with docker, then you need to follow the
+following steps.
+
+1. Copy the environment variables
+
+```sh
+cp .samplle.env .env
+vim .env
+```
+
+2. Setup and Run the app
+
+```sh
+# setup / rebuild
+make setup
+
+# run - no rebuild
+make up
+```
+
+The makefile also includes couple of other target to run the test suite or
+console in those containers. Please check out the `Makefile` for more details
 
 ## Guidelines
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,8 @@ development: &default
   pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
   reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
   timeout: 5000
+  host: <%= ENV.fetch("DATABASE_HOST", "127.0.0.1") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "") %>
 
 test:
   <<: *default

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_08_18_111301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  db:
+    image: postgres:11
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    command: /bin/sh -c "./entrypoint.sh"
+    ports:
+      - "3000:3000"
+
+    environment:
+      DATABASE_HOST: db
+      DATABASE_USERNAME: postgres
+
+    links:
+      - db
+
+    volumes:
+      - .:/relaton.org

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+wait-for-it db:5432 &&
+rm -f /relaton.org/tmp/pids/server.pid &&
+bundle exec rails server --port 3000 --binding 0.0.0.0


### PR DESCRIPTION
This commit adds the necessary set for docker, so if anyone prefers docker then they can simply use the `docker-compose` to spin up the application without having to set up every single dependency by themselves.