### PR TITLE
Allow user to specify document format

### DIFF
--- a/app/controllers/api/standards_controller.rb
+++ b/app/controllers/api/standards_controller.rb
@@ -10,7 +10,7 @@ module Api
 
     def find_standard
       if params[:code] && standard
-        render(json: standard, status: :ok)
+        render(json: standard, format: params[:document_format], status: :ok)
       end
     end
 

--- a/app/serializers/standard_serializer.rb
+++ b/app/serializers/standard_serializer.rb
@@ -1,14 +1,19 @@
 class StandardSerializer < ActiveModel::Serializer
-  attributes :id, :code, :type, :updated_at, :document
+  attributes :type, :code, :document, :updated_at
 
   def type
     object.standard_type&.upcase
   end
 
   def document
-    {
-      json: object.document_in_json,
-      xml: object.document_in_xml.force_encoding("UTF-8"),
-    }
+    xml_document || object.document_in_json
+  end
+
+  private
+
+  def xml_document
+    if @instance_options[:format].try(:to_s).try(:downcase) == "xml"
+      object.document_in_xml.force_encoding("UTF-8")
+    end
   end
 end

--- a/spec/requests/api/find_a_standard_spec.rb
+++ b/spec/requests/api/find_a_standard_spec.rb
@@ -6,13 +6,17 @@ RSpec.describe "GET /api/standards" do
       standard = create(:standard, :with_document, code: "ISO 19115")
       stub_relaton_document(standard.code, standard.year)
 
-      get_api api_standard_path(code: standard.code, year: standard.year)
-      content = JSON.parse(response.body)
+      get_api api_standard_path(
+        code: standard.code,
+        year: standard.year,
+        document_format: "xml",
+      )
 
+      content = JSON.parse(response.body)
       expect(content["updated_at"]).not_to be_nil
       expect(content["code"]).to eq(standard.code)
       expect(content["type"]).to eq(standard.standard_type.upcase)
-      expect(content["document"]["xml"]).to include('<bibitem id="ISO19115-200')
+      expect(content["document"]).to include('<bibitem id="ISO19115-2003" type')
     end
   end
 


### PR DESCRIPTION
Currently, we are responding with both `json` and `xml` document in the response, which makes our payload much larger that in need to be. In a real world scenario, a user will need one or the either, so this commit adds support for `document_format` params in the requests. Based on this the user will either receive `json` and `xml` doc.