### PR TITLE
Add configuration to run github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: GitHub CI
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.3
+
+      - name: Install dependent libraries
+        run: sudo apt-get install libpq-dev
+
+      - name: Setup app with migrations
+        run: ./bin/setup
+
+        # Currently action doesn't support 2.6.4, so this is tempory fix
+        # please remove this once github/actions has official support for 2.6.4
+        #
+        env:
+          RUBY_VERSION: 2.6.3
+          DATABASE_USERNAME: postgres
+          DATABASE_PASSWORD: postgres
+
+      - name: Run rspec tests
+        run: ./bin/rspec spec
+        env:
+          RUBY_VERSION: 2.6.3
+          DATABASE_USERNAME: postgres
+          DATABASE_PASSWORD: postgres

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby "2.6.4"
+ruby ENV["RUBY_VERSION"] || "2.6.4"
 
 gem "active_model_serializers", "~> 0.10.0"
 gem "autoprefixer-rails"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Getting Started
 
+![](https://github.com/relaton/relaton.org/workflows/GitHub%20CI/badge.svg)
+
+
 ### Native development
 
 After you have cloned this repo, run this setup script to set up your machine

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,7 @@ development: &default
   timeout: 5000
   host: <%= ENV.fetch("DATABASE_HOST", "127.0.0.1") %>
   username: <%= ENV.fetch("DATABASE_USERNAME", "") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "") %>
 
 test:
   <<: *default


### PR DESCRIPTION
This commit adds all necessary setup to build and run our test suite using the GitHub action. Currently, ruby `2.6.4` is not supported by official action, so we also added a minor hack to run on 2.6.3. Once the new version is supported then we can remove those steps.