### PR TITLE
Extract code and find processor class

### DIFF
--- a/app/models/finders/klass_finder.rb
+++ b/app/models/finders/klass_finder.rb
@@ -1,0 +1,41 @@
+module Finders
+  class KlassFinder
+    def initialize(code)
+      @code = code
+    end
+
+    def find
+      unless standard_key.empty?
+        finder_klasses[standard_key.to_sym]
+      end
+    end
+
+    def self.find(code)
+      new(code).find
+    end
+
+    private
+
+    def finder_klasses
+      @finder_klasses ||= {
+        iso: Finders::IsoStandard,
+      }
+    end
+
+    def processor_patterns
+      @processor_patterns ||= {
+        iso: { prefix: /ISO/, default: %r{^(ISO)[ /]} },
+      }
+    end
+
+    def standard_key
+      code = @code.upcase
+
+      processor_patterns.select do |name, regex|
+        if regex[:prefix].match(code) || regex[:default].match(code)
+          return name
+        end
+      end
+    end
+  end
+end

--- a/app/models/standard_finder.rb
+++ b/app/models/standard_finder.rb
@@ -9,7 +9,7 @@ class StandardFinder
 
   def find
     build_standard_object(
-      finder_klass.find(code, year),
+      standard_finder_klass.find(code, year),
     )
   end
 
@@ -18,10 +18,6 @@ class StandardFinder
   end
 
   private
-
-  def finder_klass
-    finder_klasses[standard_key.to_sym]
-  end
 
   def build_standard_object(document)
     if document
@@ -34,11 +30,7 @@ class StandardFinder
     end
   end
 
-  def finder_klasses
-    { iso: Finders::IsoStandard }
-  end
-
-  def standard_key
-    @standard_key ||= code.split(" ").first.downcase
+  def standard_finder_klass
+    @standard_finder_klass ||= Finders::KlassFinder.find(code)
   end
 end

--- a/spec/models/finders/klass_finder_spec.rb
+++ b/spec/models/finders/klass_finder_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Finders::KlassFinder do
+  describe ".find" do
+    it "returns the correct finder class with valid code" do
+      code = "ISO 19011"
+
+      finder = Finders::KlassFinder.find(code)
+      expect(finder).to eq(Finders::IsoStandard)
+    end
+
+    it "returns nil for non supported / invalid code" do
+      code = "INVALID 19011"
+
+      expect(Finders::KlassFinder.find(code)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the functionality that can be used to extract any of the supported processor class, and using this we can easily use the right one to fetch a document.