### PR TITLE
Add expiry date to standard document

### DIFF
--- a/app/controllers/api/standards_controller.rb
+++ b/app/controllers/api/standards_controller.rb
@@ -15,7 +15,7 @@ module Api
     end
 
     def standard
-      @standard ||= Standard.find_or_fetch_by(
+      @standard ||= StandardFinder.find_or_fetch_by(
         code: params[:code], year: params[:year],
       )
     end

--- a/app/models/standard.rb
+++ b/app/models/standard.rb
@@ -1,21 +1,2 @@
 class Standard < ApplicationRecord
-  def self.find_or_fetch_by(code:, **attributes)
-    attributes = attributes.merge(code: code)
-    where(attributes).take || fetch_standard(attributes)
-  end
-
-  def self.fetch_standard(attributes)
-    standard  = StandardFinder.find_by(attributes)
-
-    if standard
-      create!(
-        code: standard.code,
-        year: standard.year,
-        standard_type: standard.standard_type,
-        document_number: standard.document_number,
-        document_in_xml: standard.document_in_xml,
-        document_in_json: standard.document_in_hash,
-      )
-    end
-  end
 end

--- a/app/models/standard_fetcher.rb
+++ b/app/models/standard_fetcher.rb
@@ -1,0 +1,40 @@
+class StandardFetcher
+  attr_reader :code, :year, :standard_type, :document_number,
+    :document_in_xml, :document_in_hash
+
+  def initialize(code:, year: nil, **options)
+    @year = year
+    @options = options
+    @code = code.upcase
+  end
+
+  def fetch
+    build_standard_object(
+      relaton.fetch(code.upcase, year&.to_s, options),
+    )
+  end
+
+  def self.fetch_by(code:, year: nil, **options)
+    new(options.merge(code: code, year: year)).fetch
+  end
+
+  private
+
+  attr_reader :options
+
+  def relaton
+    @relaton ||= Relaton::Db.new(nil, nil)
+  end
+
+  def build_standard_object(document)
+    if document
+      @document_in_xml = document.to_xml
+      @document_in_hash = document.to_hash
+      @document_number = @document_in_hash["docnumber"]
+      @standard_type = @document_in_hash["docid"]["type"]&.downcase
+      @year = @year || @document_in_hash["docid"]["id"].split(":").last
+
+      self
+    end
+  end
+end

--- a/app/models/standard_finder.rb
+++ b/app/models/standard_finder.rb
@@ -1,39 +1,58 @@
 class StandardFinder
-  attr_reader :code, :year, :standard_type, :document_number,
-    :document_in_xml, :document_in_hash
-
-  def initialize(code:, year: nil, **options)
-    @year = year
-    @options = options
-    @code = code.upcase
+  def initialize(code:, **attributes)
+    @attributes = attributes.compact
+    @attributes[:code] = normalize_code(code)
   end
 
-  def find
-    build_standard_object(
-      relaton.fetch(code.upcase, year&.to_s, options),
-    )
+  def find_or_fetch
+    find_standard || fetch_standard
   end
 
-  def self.find_by(code:, year: nil, **options)
-    new(options.merge(code: code, year: year)).find
+  def self.find_or_fetch_by(code:, **attributes)
+    new(code: code, **attributes).find_or_fetch
   end
 
   private
 
-  attr_reader :options
+  attr_reader :attributes
 
-  def relaton
-    @relaton ||= Relaton::Db.new(nil, nil)
+  def normalize_code(code)
+    code.gsub("  ", " ").strip.upcase
   end
 
-  def build_standard_object(document)
-    if document
-      @document_in_xml = document.to_xml
-      @document_in_hash = document.to_hash
-      @document_number = @document_in_hash["docnumber"]
-      @standard_type = @document_in_hash["docid"]["type"]&.downcase
+  def find_standard
+    Standard.where(attributes).order(year: :desc).take
+  end
 
-      self
+  def fetch_standard
+    standard = StandardFetcher.fetch_by(attributes)
+
+    if standard
+      store_new_standard(standard)
     end
+  end
+
+  def store_new_standard(standard)
+    Standard.create!(
+      code: standard.code,
+      year: standard.year,
+      standard_type: standard.standard_type,
+      document_number: standard.document_number,
+      document_in_xml: standard.document_in_xml,
+      document_in_json: standard.document_in_hash,
+      expires_at: set_document_expiry_date(standard),
+    )
+  end
+
+  def set_document_expiry_date(standard)
+    if short_cached_standards.include?(standard.standard_type.upcase)
+      5.days.from_now
+    else
+      15.days.from_now
+    end
+  end
+
+  def short_cached_standards
+    @short_cached_standards ||= ["ISO", "CHINESE STANDARD"]
   end
 end

--- a/db/migrate/20191010102606_add_expires_at_to_standards.rb
+++ b/db/migrate/20191010102606_add_expires_at_to_standards.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToStandards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :standards, :expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_07_162442) do
+ActiveRecord::Schema.define(version: 2019_10_10_102606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_09_07_162442) do
     t.jsonb "document_in_json"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "expires_at"
     t.index ["code"], name: "index_standards_on_code"
     t.index ["document_number"], name: "index_standards_on_document_number"
   end

--- a/spec/models/standard_fetcher_spec.rb
+++ b/spec/models/standard_fetcher_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe StandardFetcher do
+  describe ".fetch_by" do
+    context "with valid standard details" do
+      it "finds and returns the standard" do
+        year = 2003
+        code = "ISO 19115"
+        stub_relaton_document(code, year)
+
+        standard = StandardFetcher.fetch_by(code: code, year: year)
+        hash_document = standard.document_in_hash
+
+        expect(standard.code).to eq(code)
+        expect(standard.year).to eq(year)
+        expect(standard.standard_type).to eq("iso")
+        expect(standard.document_number).to eq("19115")
+        expect(hash_document["date"]["value"]).to eq("2003-01-01")
+        expect(hash_document["docid"]["id"]).to eq("ISO 19115:2003")
+        expect(standard.document_in_xml).to include('<bibitem id="ISO19115-200')
+      end
+    end
+
+    context "with invalid standard details" do
+      it "does not returns anything but nil" do
+        year = 2019
+        code = "ISO 19115"
+
+        stub_relaton_invalid_document(code, year)
+        standard = StandardFetcher.fetch_by(code: code, year: year)
+
+        expect(standard).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/standard_spec.rb
+++ b/spec/models/standard_spec.rb
@@ -1,36 +1,4 @@
 require "rails_helper"
 
 RSpec.describe Standard, type: :model do
-  describe ".find_or_fetch_by" do
-    context "with existing document" do
-      it "returns the correct document" do
-        standard = create(:standard, :with_document)
-
-        found_standard = Standard.find_or_fetch_by(
-          code: standard.code, year: standard.year,
-        )
-
-        expect(found_standard).to eq(standard)
-        expect(found_standard.year).to eq(standard.year)
-      end
-    end
-
-    context "with non existing document" do
-      it "fetch and returns the new document" do
-        standard_fixture = build(:standard)
-        stub_relaton_document(standard_fixture.code, standard_fixture.year)
-
-        standard = Standard.find_or_fetch_by(
-          code: standard_fixture.code, year: standard_fixture.year,
-        )
-
-        expect(standard.code).to eq(standard_fixture.code)
-        expect(standard.year).to eq(standard_fixture.year)
-        expect(standard.standard_type).to eq(standard_fixture.standard_type)
-        expect(standard.document_in_json["date"]["value"]).to eq("2003-01-01")
-        expect(standard.document_in_xml).to include('<bibitem id="ISO19115-200')
-        expect(standard.document_number).to eq(standard_fixture.document_number)
-      end
-    end
-  end
 end


### PR DESCRIPTION
This commit restructure some code, and it also do some changes in the way to find a document. Now, it will only use the attributes user has supplied to find a standard. This also normalize some of the attributes, so we don't store duplicates copies for multiple strings.

This commit add also adds `expires_at` date to the `Standard` table. When storing a new document, then by default it will set 15 days validity, but if those are the specific use cases then it will only set it for 5 days.

Related: #10