### PR TITLE
Add rake task to remove expired standards

### DIFF
--- a/app/models/standard.rb
+++ b/app/models/standard.rb
@@ -1,2 +1,5 @@
 class Standard < ApplicationRecord
+  def self.expired_in(timestamp)
+    where("expires_at <= ?", timestamp)
+  end
 end

--- a/lib/tasks/relaton.rake
+++ b/lib/tasks/relaton.rake
@@ -1,0 +1,8 @@
+namespace :relaton do
+  desc "Remove expired standard documents"
+  task :cleanup => :environment do
+    Standard.expired_in(1.hours.ago).select(:id).in_batches do |standards|
+      standards.destroy_all
+    end
+  end
+end

--- a/spec/lib/tasks/relaton_cleanup_spec.rb
+++ b/spec/lib/tasks/relaton_cleanup_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "relaton:cleanup" do
+  include_context "rake"
+
+  it "removes all expired document" do
+    _standard_one = create(:standard, expires_at: 1.days.ago)
+    _standard_two = create(:standard, expires_at: 5.days.ago)
+
+    standard_three = create(:standard, expires_at: 1.hours.from_now)
+    standard_four = create(:standard, expires_at: 1.days.from_now)
+
+    subject.invoke
+
+    expect(Standard.count).to eq(2)
+    expect(Standard.all.map(&:id)).to eq([standard_three.id, standard_four.id])
+  end
+end

--- a/spec/models/standard_spec.rb
+++ b/spec/models/standard_spec.rb
@@ -1,4 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Standard, type: :model do
+  describe ".expired_in" do
+    it "returns expired standard upto that time" do
+      standard_one = create(:standard, expires_at: 1.days.ago)
+      standard_two = create(:standard, expires_at: 1.hours.ago)
+
+      _standard_three = create(:standard, expires_at: 1.hours.from_now)
+      _standard_four = create(:standard, expires_at: 4.days.from_now)
+
+      expect(
+        Standard.expired_in(1.hours.ago).map(&:id),
+      ).to eq([standard_one.id, standard_two.id])
+    end
+  end
 end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,19 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
This commit adds a rake task, this task selects and can be used to remove all of the expired standard documents. Ideally, we will only need to plug this task a daily cron/scheduled job and it will take care of the test.

<img width="651" alt="Screen Shot 2019-10-10 at 5 35 44 PM" src="https://user-images.githubusercontent.com/1220911/66565798-2b3b6000-eb85-11e9-8e28-7bad2e747546.png">


Closes #10