### PR TITLE
Improve docker-compose setup for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim-stretch
+FROM ruby:2.6.5-slim-stretch
 
 RUN apt-get update -qq && apt-get install -yy curl wget
 
@@ -15,11 +15,8 @@ RUN npm install yarn -g
 # Create app directory
 WORKDIR /relaton.org
 
-# Copy gemfile
-COPY Gemfile* ./
-
-# Install dependencies
-RUN bundle install
+# Set bundle path
+ENV BUNDLE_PATH /bundle
 
 # Copy the application
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ console:
 .PHONY: setup
 setup:
 	docker-compose build
-	docker-compose run web bin/rails db:setup
+	docker-compose run web bin/setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     ports:
       - "5432:5432"
 
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
   web:
     build: .
     command: /bin/sh -c "./entrypoint.sh"
@@ -21,3 +27,8 @@ services:
 
     volumes:
       - .:/relaton.org
+      - bundle:/bundle
+
+volumes:
+  bundle:
+  postgres-data:


### PR DESCRIPTION
The current docker file has two issues, one is it tries to install bundler dependencies in each build and second of all Postgres data resets in each setup. This adds some extra time when we need to do a quick test.

This commit changes these, and it adds docker's mountable volumes, so now whenever we run bundler then it will use this directory to store it's dependencies and also share between these builds. The same goes for the Postgres data persistence.