### PR TITLE
Build gems cache for GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-ruby@v1
         with:
@@ -33,14 +33,23 @@ jobs:
       - name: Install dependent libraries
         run: sudo apt-get install libpq-dev
 
+      - name: Cache Dependencies
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gem-
+
       - name: Setup app with migrations
         run: ./bin/setup
         env:
+          BUNDLE_PATH: vendor/bundle
           DATABASE_USERNAME: postgres
           DATABASE_PASSWORD: postgres
 
       - name: Run rspec tests
         run: ./bin/rspec spec
         env:
+          BUNDLE_PATH: vendor/bundle
           DATABASE_USERNAME: postgres
           DATABASE_PASSWORD: postgres


### PR DESCRIPTION
Currently each github action build is installing our dependencies, even if we didn't add any new dependencies. This commit adds another step to build a cache, and then later use that one when there are no changes in our dependencies.